### PR TITLE
docs: bump `actions/create-github-app-token` action

### DIFF
--- a/content/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions.md
+++ b/content/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions.md
@@ -67,7 +67,7 @@ jobs:
     # Replace `APP_PEM` with the name of the secret that contains your app private key.
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: {% raw %}${{ vars.APP_ID }}{% endraw %}
           private-key: {% raw %}${{ secrets.APP_PEM }}{% endraw %}

--- a/content/rest/quickstart.md
+++ b/content/rest/quickstart.md
@@ -76,7 +76,7 @@ If you are authenticating with a {% data variables.product.prodname_github_app %
        steps:
          - name: Generate token
            id: generate-token
-           uses: actions/create-github-app-token@v1
+           uses: actions/create-github-app-token@v2
            with:
              app-id: {% raw %}${{ vars.APP_ID }}{% endraw %}
              private-key: {% raw %}${{ secrets.APP_PEM }}{% endraw %}
@@ -227,7 +227,7 @@ If you are authenticating with a {% data variables.product.prodname_github_app %
 
          - name: Generate token
            id: generate-token
-           uses: actions/create-github-app-token@v1
+           uses: actions/create-github-app-token@v2
            with:
              app-id: {% raw %}${{ vars.APP_ID }}{% endraw %}
              private-key: {% raw %}${{ secrets.APP_PEM }}{% endraw %}
@@ -321,7 +321,7 @@ If you are authenticating with a {% data variables.product.prodname_github_app %
        steps:
          - name: Generate token
            id: generate-token
-           uses: actions/create-github-app-token@v1
+           uses: actions/create-github-app-token@v2
            with:
              app-id: {% raw %}${{ vars.APP_ID }}{% endraw %}
              private-key: {% raw %}${{ secrets.APP_PEM }}{% endraw %}


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- update actions/create-github-app-token references from v1 to v2 in quickstart and automation guides