### PR TITLE
docs: bump `actions/go-dependency-submission` action

### DIFF
--- a/data/reusables/dependency-submission/premade-action-table.md
+++ b/data/reusables/dependency-submission/premade-action-table.md
@@ -40,7 +40,7 @@ jobs:
           go-version: ">=1.18.0"
 
       - name: Run snapshot action
-        uses: actions/go-dependency-submission@v1
+        uses: actions/go-dependency-submission@v2
         with:
             # Required: Define the repo path to the go.mod file used by the
             # build target


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Bump actions/go-dependency-submission from v1 to v2 in the premade action table