### PR TITLE
docs: bump `actions/download-artifact` GitHub Actions

### DIFF
--- a/data/reusables/actions/action-download-artifact.md
+++ b/data/reusables/actions/action-download-artifact.md
@@ -1,1 +1,1 @@
-actions/download-artifact@{% ifversion artifacts-v3-deprecation %}v4{% else %}v3{% endif %}
+actions/download-artifact@{% ifversion artifacts-v3-deprecation %}v5{% else %}v3{% endif %}


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Bump actions/download-artifact from v4 to v5 when artifacts-v3-deprecation is enabled