### PR TITLE
docs: typo `demographical` → `demographic`

### DIFF
--- a/content/site-policy/privacy-policies/github-cookies.md
+++ b/content/site-policy/privacy-policies/github-cookies.md
@@ -112,6 +112,6 @@ GitHub | `user_session` | This cookie is used to log you in. | Two weeks
 [Quantcast](https://www.quantcast.com/privacy/) | `d` | This cookie is used for Market and Audience Segmentation and Targeted advertising services. | 3 months
 [Quantcast](https://www.quantcast.com/privacy/) | `mc` | This cookie is used to track anonymous information about how website visitors use the site. | 13 months
 [Yahoo](https://policies.yahoo.com/us/en/yahoo/privacy/index.htm?redirect=no) | `A3` | This cookie is used for search and advertising. | One year
-[Yahoo](https://policies.yahoo.com/us/en/yahoo/privacy/index.htm?redirect=no) | `b` | This cookie collects anonymous data related to the visitor's website visits, such as the number of visits, average time spent on the website and what pages have been loaded. The registered data is used to categorize the users' interest and demographical profiles with the purpose of customizing the website content depending on the visitor. | One year
+[Yahoo](https://policies.yahoo.com/us/en/yahoo/privacy/index.htm?redirect=no) | `b` | This cookie collects anonymous data related to the visitor's website visits, such as the number of visits, average time spent on the website and what pages have been loaded. The registered data is used to categorize the users' interest and demographic profiles with the purpose of customizing the website content depending on the visitor. | One year
 
 (*) The expiration dates for the cookies listed above generally apply on a rolling basis.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct typo from 'demographical' to 'demographic' in GitHub cookies privacy policy document