### PR TITLE
docs: bump `actions/checkout` GitHub Actions

### DIFF
--- a/data/reusables/actions/action-checkout.md
+++ b/data/reusables/actions/action-checkout.md
@@ -1,1 +1,1 @@
-actions/checkout@v4
+actions/checkout@v5


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Bump actions/checkout version from v4 to v5 in data/reusables/actions/action-checkout.md